### PR TITLE
Fix: Resolve ESLint violations and improve type safety

### DIFF
--- a/src/pages/BookForm.tsx
+++ b/src/pages/BookForm.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useBookStore } from '../stores/bookStore';
-import { ArrowLeft, Save, BookOpen } from 'lucide-react';
+import { ArrowLeft, Save } from 'lucide-react';
 import { BookFormData, Career } from '../types';
 import { careerNames } from '../utils/mockData';
 import toast from 'react-hot-toast';
@@ -148,7 +148,7 @@ const BookForm: React.FC = () => {
       }
       
       navigate(`/catalog/${formData.career}`);
-    } catch (error) {
+    } catch {
       toast.error('Ha ocurrido un error');
     } finally {
       setIsSubmitting(false);

--- a/src/pages/LoanRecords.tsx
+++ b/src/pages/LoanRecords.tsx
@@ -74,7 +74,7 @@ const LoanRecords: React.FC = () => {
       } else {
         toast.error('Error al procesar la devolución');
       }
-    } catch (error) {
+    } catch {
       toast.error('Ha ocurrido un error');
     } finally {
       setIsProcessing(false);
@@ -88,7 +88,7 @@ const LoanRecords: React.FC = () => {
       try {
         await deleteLoan(id);
         toast.success('Registro eliminado correctamente');
-      } catch (error) {
+      } catch {
         toast.error('Ha ocurrido un error');
       } finally {
         setIsProcessing(false);
@@ -103,7 +103,7 @@ const LoanRecords: React.FC = () => {
       try {
         await deleteAllLoans();
         toast.success('Todos los registros han sido eliminados');
-      } catch (error) {
+      } catch {
         toast.error('Ha ocurrido un error');
       } finally {
         setIsProcessing(false);
@@ -125,7 +125,7 @@ const LoanRecords: React.FC = () => {
             : 'Todos'
         }`
       );
-    } catch (error) {
+    } catch {
       toast.error('Error al generar el PDF');
     }
   };

--- a/src/pages/Students.tsx
+++ b/src/pages/Students.tsx
@@ -1,6 +1,6 @@
 // src/pages/Students.tsx
 
-import React, { useMemo, useState, useEffect } from 'react';
+import React, { useMemo, useState } from 'react';
 // No es necesario Link aquí si toda la gestión es modal y no hay navegación a una página de formulario separada.
 // Si necesitas Link para otras cosas (ej. ir a Dashboard), mantenlo.
 // import { Link } from 'react-router-dom'; 
@@ -10,9 +10,7 @@ import {
   Edit, 
   Trash2, 
   Search, 
-  Filter as FilterIcon,
   X,
-  User as UserIcon, // Cambiado para evitar conflicto con el tipo Student
   Briefcase, 
   Hash, 
   Users as UsersIcon, // Para el ícono de "No hay estudiantes"

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -42,7 +42,8 @@ export const useAuthStore = create<AuthState>()(
         
         if (user) {
           // Remove password before storing user data
-          const { password, ...userWithoutPassword } = user;
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { password: _password, ...userWithoutPassword } = user;
           set({ user: userWithoutPassword, isAuthenticated: true });
           return true;
         }

--- a/src/stores/loanStore.ts
+++ b/src/stores/loanStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import { Loan, LoanFormData } from '../types';
+import { Loan, LoanFormData, Student } from '../types';
 import { useBookStore } from './bookStore';
 import { generateMockLoans } from '../utils/mockData';
 
@@ -45,7 +45,7 @@ export const useLoanStore = create<LoanState>()(
           id: crypto.randomUUID(),
           ...loanData,
           book,
-          student: {} as any, // This would be filled in a real application
+          student: {} as Student, // This would be filled in a real application
           status: 'active',
           createdAt: new Date().toISOString(),
           updatedAt: new Date().toISOString(),

--- a/src/utils/pdf.ts
+++ b/src/utils/pdf.ts
@@ -5,9 +5,21 @@ import { format } from 'date-fns';
 import { careerNames } from './mockData';
 
 // Type definition for jspdf-autotable
+// Type definition for jspdf-autotable options
+interface AutoTableOptions {
+  head?: (string | number)[][];
+  body?: (string | number)[][];
+  startY?: number;
+  styles?: Record<string, string | number>;
+  headStyles?: Record<string, string | number>;
+  alternateRowStyles?: Record<string, string | number>;
+  margin?: Record<string, string | number>;
+  // Add other options used by autoTable if necessary
+}
+
 declare module 'jspdf' {
   interface jsPDF {
-    autoTable: (options: any) => jsPDF;
+    autoTable: (options: AutoTableOptions) => jsPDF;
   }
 }
 


### PR DESCRIPTION
Resolved various ESLint errors, including:
- Removed unused variable imports and declarations.
- Replaced 'any' types with more specific type definitions, particularly for jspdf-autotable options and store typings.
- Ensured compliance with the no-unused-vars rule.

These changes improve code quality, maintainability, and type safety across the affected files.